### PR TITLE
Fix ReasonML match pattern

### DIFF
--- a/public/icon_associations.json
+++ b/public/icon_associations.json
@@ -3512,7 +3512,7 @@
 					"fileNames": "*.re,*.rei",
 					"name": "ReasonML",
 					"color": "D52A29",
-					"pattern": ".*\\.rei?",
+					"pattern": ".*\\.rei?$",
 					"icon": "/icons/files/reason.svg"
 				},
 				{


### PR DESCRIPTION
Current pattern may mistake other files as ReasonML files: https://github.com/denoland/deno_website2/tree/master/pages/x

![image](https://user-images.githubusercontent.com/44045911/89248200-b8363500-d641-11ea-85a7-9246c5381be7.png)

P.S. Patterns matching certain file extensions possibly should always end with `$`, but lots of them are missing it now (like `Racket` `Red`...) 
