### PR TITLE
feat: GitHub code-view file icons

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-import { injectIconsBitbucket, injectIconsGitee, injectIconsGithubv2, injectIconsGitlab, injectIconsPullRequests, injectIconsSearch } from './providers';
+import { injectIconsBitbucket, injectIconsGitee, injectIconsGithubv2, injectIconsGitlab, injectIconsPullRequests, injectIconsSearch, injectIconsGithubCodeView } from './providers';
 import select from 'select-dom';
 
 function init() {
@@ -7,21 +7,31 @@ function init() {
   function apply(target) {
     if (select.exists('.js-navigation-item > [role="gridcell"]', target)) {
       injectIconsGithubv2(target);
+      return;
     }
     else if (select.exists('.tree-browser-result > .octicon', target)) {
       injectIconsSearch(target);
-    }
-    else if (select.exists('.ActionList-item-visual > .octicon', target)) {
-      injectIconsPullRequests(target);
+      return;
     }
     else if (select.exists('.css-hix1c1 > [data-qa="repository-directory"]', target)) {
       injectIconsBitbucket(target);
+      return;
     }
     else if (select.exists('.tree-content-holder [data-qa-selector="file_tree_table"]', target)) {
       injectIconsGitlab(target);
+      return;
     }
     else if (select.exists('.tree-table .tree-item', target)) {
       injectIconsGitee(target);
+      return;
+    }
+
+    // GitHub's code-view has both the .ActionList and the directory view
+    if (select.exists('.ActionList-item-visual > .octicon', target)) {
+      injectIconsPullRequests(target);
+    }
+    if (select.exists('.react-directory-filename-column', target)) {
+      injectIconsGithubCodeView(target);
     }
   }
 

--- a/src/providers/githubCodeView.js
+++ b/src/providers/githubCodeView.js
@@ -1,0 +1,28 @@
+import { getAssociation, getFileIcon, getFileIconName, getFolderAssociation, getFolderIcon, getFolderIconName } from '../associations';
+import select from 'select-dom';
+
+export function injectIconsGithubCodeView(target) {
+  const $items = select.all('.react-directory-filename-column', target);
+    
+  $items.forEach((item, index) => {
+    const isDir = select.exists('.icon-directory', item);
+    const name = select('.react-directory-truncate', item)?.textContent?.trim();
+    const $icon = select('svg', item);
+
+    if (name) {
+      if (isDir) {
+        let assoc = getFolderAssociation(name);
+        let className = getFolderIconName(assoc);
+  
+        const icon = getFolderIcon(className);
+        $icon.innerHTML = icon.default;
+      } else {
+        let assoc = getAssociation(name);
+        let className = getFileIconName(assoc);
+
+        const icon = getFileIcon(className);
+        $icon.innerHTML = icon.default;
+      }
+    }
+  });
+}

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -4,3 +4,4 @@ export * from './githubv2';
 export * from './gitlab';
 export * from './gitee';
 export * from './pullRequests';
+export * from './githubCodeView';


### PR DESCRIPTION
This PR adds file and folder icons to items in the directory view on GitHub's new code-view:

![](https://user-images.githubusercontent.com/19953266/201473950-7b440066-1cd9-4f23-98b0-52606a79084e.png)

The tree-view on the left uses the `pullRequest.js` provider and the directory-view in the middle uses the `githubCodeView.js` provider. This means that in `main.js > init() > apply(target)`, both providers need to be checked.

Closes #197.